### PR TITLE
Add default BOOL return to cyclic method

### DIFF
--- a/TcPluginFramework/TcPluginFramework/Interfaces/ITaskState.TcIO
+++ b/TcPluginFramework/TcPluginFramework/Interfaces/ITaskState.TcIO
@@ -6,7 +6,7 @@
 INTERFACE ITaskState
 ]]></Declaration>
     <Method Name="Cyclic" Id="{df7848e1-6796-42e6-952c-938fef13bd38}">
-      <Declaration><![CDATA[METHOD Cyclic
+      <Declaration><![CDATA[METHOD Cyclic : BOOL
 ]]></Declaration>
     </Method>
     <Method Name="Inihibits" Id="{e83ce640-e6f2-45e5-949b-c526c3174821}">

--- a/TcPluginFramework/TcPluginFramework/POUs/ComponentBase.TcPOU
+++ b/TcPluginFramework/TcPluginFramework/POUs/ComponentBase.TcPOU
@@ -15,7 +15,7 @@ Run();]]></ST>
     <Folder Name="ApplicationOverrides" Id="{f2009942-3f7f-4941-bfa7-741ffc14e21c}" />
     <Folder Name="Internal" Id="{e1a9125c-f3ee-490f-ba83-a56d67f46885}" />
     <Method Name="Cyclic" Id="{f52824b0-33e3-4c0b-be35-3a5b4aa4be2f}" FolderPath="ApplicationOverrides\">
-      <Declaration><![CDATA[METHOD Cyclic
+      <Declaration><![CDATA[METHOD Cyclic : BOOL
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.

--- a/TcPluginFramework/TcPluginFramework/TcPluginFramework.plcproj
+++ b/TcPluginFramework/TcPluginFramework/TcPluginFramework.plcproj
@@ -19,7 +19,7 @@
     <Company>Loupe</Company>
     <Released>false</Released>
     <Title>TcPluginFramework</Title>
-    <ProjectVersion>0.0.4</ProjectVersion>
+    <ProjectVersion>1.0.0</ProjectVersion>
     <CombineIds>true</CombineIds>
     <LibraryCategories>
       <LibraryCategory xmlns="">


### PR DESCRIPTION
## What:
Add a default BOOL return to the signature of the Cyclic method within ITaskState.

## Why:
When extending a FB such as ComponentBase within TwinCAT and overriding a method liike Cyclic(), a default signature with a BOOL return is added by the IDE. This generates a build error for a non-matching declaration, which is an annoyance and surprising to users.

The default BOOL return signature had been removed in early library development for clarity, as there is no meaningful value intended to be returned. However it's an anomoly not repeated in other libraries here, that is just causing confusion.

## Important note:
This will have effects on our other libraries. I'm working on identifying those so the PRs can be made together along with version bumps.